### PR TITLE
Feature esc overlay disable enable

### DIFF
--- a/jQuery.leanModal2.js
+++ b/jQuery.leanModal2.js
@@ -19,7 +19,9 @@
 			var defaults = {
 				top: 100,
 				overlayOpacity: 0.5,
-				closeButton: false
+				closeButton: false,
+				disableCloseOnOverlayClick: false,
+           		disableCloseOnEscape: false,
 			};
 
 			// Merge in the passed options.
@@ -51,7 +53,9 @@
 
 					// Set the function to close the overlay if you click it.
 					$('.js-target-jquery-leanmodal-overlay').click(function() {
-						leanModal_Close(modal_id);
+						if(!options.disableCloseOnOverlayClick) {
+							leanModal_Close(modal_id);
+						}
 					});
 
 					// If a close button is set, link it to the close command.
@@ -63,8 +67,10 @@
 
 					// Close the modal on escape
 					$(document).on('keyup', function(evt) {
-						if (evt.keyCode == 27) {
-							leanModal_Close(modal_id);
+						if(!options.disableCloseOnEscape) {			
+							if (evt.keyCode == 27) {
+								leanModal_Close(modal_id);
+							}
 						}
 					});
 


### PR DESCRIPTION
Example 

```
 $('.open-paymentprogress-modal').leanModal({
        disableCloseOnOverlayClick: true,
        disableCloseOnEscape: true,
        closeButton: '.close-paymentprogress-modal'
});
```
